### PR TITLE
Bug Fix: Unable to find chado_feature__organism_id on feature pages.

### DIFF
--- a/includes/tripal_jbrowse_instance.fields.inc
+++ b/includes/tripal_jbrowse_instance.fields.inc
@@ -102,9 +102,9 @@ function tripal_jbrowse_instance_bundle_instances_info($entity_type, $bundle) {
         'term_name' => 'genome_visualisation',
         'term_accession' => '3208',
         'auto_attach' => TRUE,
-        //'chado_table' => $field_table,
-        //'chado_column' => 'organism_id',
-        //'base_table' => $field_table,
+        'chado_table' => $field_table,
+        'chado_column' => 'organism_id',
+        'base_table' => $field_table,
       ],
       'widget' => [
         'type' => 'operation__genome_visualisation_widget',


### PR DESCRIPTION
When using the field for this module on genetic_marker pages I was seeing the following error in my Recent Messages log.

```
Notice: Undefined index: chado-feature__organism_id in operation__genome_visualisation->load() (line 131 of /home/www/fresh/sites/all/modules/contrib/tripal_jbrowse_instance/includes/TripalFields/operation__genome_visualisation/operation__genome_visualisation.inc).
```

This was caused by the [parent::load($entity)](https://github.com/statonlab/tripal_jbrowse_instance/blob/master/includes/TripalFields/operation__genome_visualisation/operation__genome_visualisation.inc#L124) being unable to load the organism_id since it didn't know what the column mapping was.